### PR TITLE
[fix] : 배포 도메인에서는 rest docs가 적용되지 않는 문제를 해결한다

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -35,7 +35,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: ⏱️gradle build 중입니다.
-        run: ./gradlew build -x test
+        run: ./gradlew clean build openapi3 asciidoctor
 
       - name: ⏱️NCP Container Registry에 로그인 후, docker image build 후 NCP Container Registry에 push합니다.
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
+# 빌드 단계
 FROM openjdk:17-jdk-slim as build
 
 WORKDIR /app
 
-# 빌드된 JAR 파일과 정적 문서 파일을 Docker 이미지에 복사
-COPY ./build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
-COPY ./build/resources/main/static/docs /app/static/docs
+# Gradle 빌드 실행
+COPY . .
+RUN ./gradlew clean build -x test
 
-# 최종 이미지
+# 최종 이미지 단계
 FROM openjdk:17-jdk-alpine as final
 
 WORKDIR /app
 
-COPY --from=build /app/app.jar app.jar
-COPY --from=build /app/static/docs /app/static/docs
+# 빌드된 JAR 파일과 정적 문서 파일을 복사
+COPY --from=build /app/build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /app/build/resources/main/static/docs /app/static/docs
 
 # HEALTHCHECK 추가
 HEALTHCHECK --interval=5s --timeout=3s --start-period=30s --retries=3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,11 @@
-# 빌드 단계
-FROM openjdk:17-jdk-slim as build
-
-WORKDIR /app
-
-# Gradle 빌드 실행
-COPY . .
-RUN ./gradlew build openapi3 asciidoctor
-
 # 최종 이미지 단계
 FROM openjdk:17-jdk-alpine as final
 
 WORKDIR /app
 
 # 빌드된 JAR 파일과 정적 문서 파일을 복사
-COPY --from=build /app/build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
-COPY --from=build /app/build/resources/main/static/docs /app/static/docs
+COPY ./build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
+COPY ./build/resources/main/static/docs /app/static/docs
 
 # HEALTHCHECK 추가
 HEALTHCHECK --interval=5s --timeout=3s --start-period=30s --retries=3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 # Gradle 빌드 실행
 COPY . .
-RUN ./gradlew clean build -x test
+RUN ./gradlew build openapi3 asciidoctor
 
 # 최종 이미지 단계
 FROM openjdk:17-jdk-alpine as final

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
-# Alpine & Slim 이미지 사용 (용량 및 보안 개선)
-# 버전 명시 (latest 지양)
-# 최종 이미지의 경량화를 위해 Multi-Stage 빌드 사용
 FROM openjdk:17-jdk-slim as build
 
 WORKDIR /app
 
+# 빌드된 JAR 파일과 정적 문서 파일을 Docker 이미지에 복사
 COPY ./build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
+COPY ./build/resources/main/static/docs /app/static/docs
 
-# 최종 이미지: 경량화된 Alpine 이미지를 사용하여 빌드된 파일을 실행
+# 최종 이미지
 FROM openjdk:17-jdk-alpine as final
 
 WORKDIR /app
 
 COPY --from=build /app/app.jar app.jar
+COPY --from=build /app/static/docs /app/static/docs
 
 # HEALTHCHECK 추가
-# 컨테이너가 시작된 후 5초마다, 최대 3초 동안 http://localhost:8080으로 헬스 체크
 HEALTHCHECK --interval=5s --timeout=3s --start-period=30s --retries=3 \
   CMD curl --fail http://localhost:8080 || exit 1
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ sourceSets {
     }
 }
 
-def serverUrl = "http://localhost:8080"
+def serverUrl = "https://git.hitzone.store"
 
 openapi3 {
     server = serverUrl

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -86,6 +86,9 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+  web:
+    resources:
+      static-locations: classpath:/static/
 
 clova:
   api:


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 기존 미적용 화면

<img width="1696" alt="배포서버_restdocs_미적용" src="https://github.com/user-attachments/assets/2916ac52-6a73-4012-bae2-6cfc17a197bc">

- 로컬에서는 rest docs가 잘 적용되었지만, 배포 서버에서는 계속해서 적용되지 않는 문제가 있었습니다.
- 이는 `open-api-3.0.1.json`가 제대로 생성되지 않았음이라고 판단하고, 도커 컨테이너 내부를 살펴보았습니다.

### 도커 컨테이너 내부

<img width="400" alt="1  restdocs 파일 제대로 생성 안됨" src="https://github.com/user-attachments/assets/82bd01a8-7b8f-40c4-9fdc-a4c487c8ee34">

- 내부로 들어가 `open-api-3.0.1.json`를 확인해 본 결과, 제대로 생성되지 않았음을 확인할 수 있었습니다.
- 이를 해결하기 위해 다양한 방법을 시도했습니다.

### 시도 1. 도커파일 수정

- 도커파일에 빌드 부분을 추가하고, `openapi3 & asciidoctor`와 같은 옵션도 추가하였습니다.
- 하지만 여전히 `open-api-3.0.1.json`은 빈 상태로 생성되었습니다.

### 시도 2.Github Actions 스크립트 수정

- Github Actions 과정을 살펴보던 중, 아래의 부분이 눈에 띄었습니다.
<img width="242" alt="테스트 안하는 설정이 문제임" src="https://github.com/user-attachments/assets/f4b10cfc-2861-46f7-a934-a2480ae6e049">

- `-x test`는 테스트를 하지 않는다는 것을 의미했고, 이 때문에 빌드 시 테스트가 되지 않아 `open-api-3.0.1.json`이 정상적으로 생성되지 않았습니다.
- 때문에 아래와 같이 스크립트를 수정했고
```yml
...
      - name: ⏱️gradle build를 위한 권한을 부여합니다.
        run: chmod +x gradlew

      - name: ⏱️gradle build 중입니다.
        run: ./gradlew clean build openapi3 asciidoctor
...
```
- 도커파일에서도 불필요한 빌드 부분을 제거하였습니다.
```dockerfile
# 최종 이미지 단계
FROM openjdk:17-jdk-alpine as final

WORKDIR /app

# 빌드된 JAR 파일과 정적 문서 파일을 복사
COPY ./build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
COPY ./build/resources/main/static/docs /app/static/docs

# HEALTHCHECK 추가
HEALTHCHECK --interval=5s --timeout=3s --start-period=30s --retries=3 \
  CMD curl --fail http://localhost:8080 || exit 1

ENTRYPOINT ["java", "-jar", "app.jar"]

EXPOSE 8080
```
### 결과

<img width="1705" alt="json 잘 생김" src="https://github.com/user-attachments/assets/0fd676f7-71e7-456a-80b8-843efa45bc9a">

- 위와 같이 컨테이너 내부에 `open-api-3.0.1.json`이 잘 생성되었으며,

#### 배포서버 rest docs 적용 성공

<img width="1696" alt="배포서버_restdocs_적용성공" src="https://github.com/user-attachments/assets/ce419e0e-d651-4411-9f12-66030e7bdfa3">

#### 배포서버 rest docs 테스트 성공

<img width="1413" alt="배포서버_테스트성공" src="https://github.com/user-attachments/assets/84d6ea9c-00dc-4766-8bc6-f2983f0d06f4">

- 배포 서버에서도 적용 및 테스트를 할 수 있었습니다.

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #33 

---

## 🎸 기타 사항 or 추가 코멘트

그동안 테스트 코드를 짜지 않아 `-x test`를 무의식적으로 사용했다는 점이 부끄럽습니다..🥲
이번 계기로 테스트 코드를 꼭 짜야하며, 빌드 단계부터 코드를 신경써야겠다고 생각이 들었습니다!