### PR TITLE
[feat] : 구역 가이드 정보 조회 시 이미지 URL을 함께 반환한다

### DIFF
--- a/src/main/java/kusitms/backend/result/domain/enums/JamsilStadiumStatusType.java
+++ b/src/main/java/kusitms/backend/result/domain/enums/JamsilStadiumStatusType.java
@@ -11,7 +11,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public enum JamsilStadiumStatusType implements StadiumStatusType {
 
-    RED("레드석",
+    RED("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/red.svg",
+            "레드석",
             "해당 구역은 다양한 것들을 모두 적절히 즐길 수 있는 구역이예요.",
             List.of("응원도 적당히 즐길 수 있지만, 야구나 함께 온 동행자와의 대화에도 집중할 수 있는 구역이에요!"),
             "해당 구역은 다양한 것들을 모두 적절히 즐길 수 있는 구역이예요.",
@@ -41,7 +42,8 @@ public enum JamsilStadiumStatusType implements StadiumStatusType {
             "[1루] 약 25cm [3루] 약 25cm",
             ""
     ),
-    BLUE("블루석",
+    BLUE("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/blue.svg",
+            "블루석",
             "힘차게 응원도 가능하고, 야구에 집중도 할 수 있는 구역이에요!",
             List.of("힘차게 응원도 가능하고, 야구에 집중도 할 수 있는 구역이에요!"),
             "해당 구역은 비교적 조용히 경기 관람이 가능한 구역이예요.",
@@ -69,7 +71,8 @@ public enum JamsilStadiumStatusType implements StadiumStatusType {
             "[1루 & 3루] 약 30~38cm",
             ""
     ),
-    NAVY("네이비석",
+    NAVY("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/navy.svg",
+            "네이비석",
             "높은 곳에서 야구를 전체적으로 볼 수 있는 구역이에요!",
             List.of("높은 곳에서 야구를 전체적으로 볼 수 있는 구역이에요!"),
             "해당 구역은 높은 층수에 위치해 있어요.",
@@ -103,7 +106,8 @@ public enum JamsilStadiumStatusType implements StadiumStatusType {
             "약 24cm(2~20열), 123cm(10열, 11열 일부)",
             ""
     ),
-    ORANGE("오렌지석",
+    ORANGE("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/orange.svg",
+            "오렌지석",
             "야구장의 응원이 가장 열정적인 응원석 구역이에요!",
             List.of("야구장의 응원이 가장 열정적인 응원석 구역이에요!"),
             "해당 구역은 열정적인 응원이 이루어져요.",
@@ -133,7 +137,8 @@ public enum JamsilStadiumStatusType implements StadiumStatusType {
             "[1루 & 3루] 약 30cm",
             ""
     ),
-    EXITING("익사이팅석",
+    EXITING("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/exciting.svg",
+            "익사이팅석",
             "야구 필드 안에 들어와 있는 느낌을 받을 수 있는 구역이에요!",
             List.of("야구 필드 안에 들어와 있는 느낌을 받을 수 있는 구역이에요!"),
             "해당 구역은 연령제한이 있어요.",
@@ -166,7 +171,8 @@ public enum JamsilStadiumStatusType implements StadiumStatusType {
             "약 72cm(1열), 63cm(2~3열)",
             ""
     ),
-    GREEN("외야그린석",
+    GREEN("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/green.svg",
+            "외야그린석",
             "사람들이 몰리지 않아 비교적 한적하게 경기를 즐길 수 있는 구역이에요!",
             List.of("사람들이 몰리지 않아 비교적 한적하게 경기를 즐길 수 있는 구역이에요!"),
             "해당 구역은 시야 제한석이 있어요.",
@@ -199,7 +205,8 @@ public enum JamsilStadiumStatusType implements StadiumStatusType {
                     음식을 구매하셨거나, 짐이 많으시다면
                     좌석에 앉기 위해 올라가실 때 꼭 유의하세요!"""
     ),
-    TABLE("테이블석",
+    TABLE("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/table.svg",
+            "테이블석",
             "다양한 음식을 골라 테이블에 펼쳐놓고 먹을 수 있는 구역이에요!",
             List.of("다양한 음식을 골라 테이블에 펼쳐놓고 먹을 수 있는 구역이에요!"),
             "해당 구역은 예매 시 위치 확인이 필요해요.",
@@ -227,7 +234,8 @@ public enum JamsilStadiumStatusType implements StadiumStatusType {
             "약 56cm",
             ""
     ),
-    PREMIUM("프리미엄석",
+    PREMIUM("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/premium.svg",
+            "프리미엄석",
             "테이블에서 맛있는 음식을 먹으면서 선수들을 가장 가까이서 볼 수 있는 구역이에요!",
             List.of("테이블에서 맛있는 음식을 먹으면서 선수들을 가장 가까이서 볼 수 있는 구역이에요!"),
             "해당 구역은 티켓 확인을 2번 해요.",
@@ -262,6 +270,7 @@ public enum JamsilStadiumStatusType implements StadiumStatusType {
     ;
 
     private static final String DEFAULT_TITLE = "참고하세요";
+    private final String imgUrl;
     private final String zoneName;
     private final String oneLineDescription;
     private final List<String> explanations;

--- a/src/main/java/kusitms/backend/result/domain/enums/KtWizStadiumStatusType.java
+++ b/src/main/java/kusitms/backend/result/domain/enums/KtWizStadiumStatusType.java
@@ -11,7 +11,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public enum KtWizStadiumStatusType implements StadiumStatusType{
 
-    CHEERING("응원지정석",
+    CHEERING("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/cheering.svg",
+            "응원지정석",
             "응원 단상과 가까워, 야구를 열정적으로 응원할 수 있는 분위기의 구역이에요!",
             List.of("응원 단상과 가까워, 야구를 열정적으로 응원할 수 있는 분위기의 구역이에요!"),
             "해당 구역은 예매 시 응원단상 위치 확인이 필요해요.",
@@ -41,7 +42,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
             "[1루] 약 28cm [3루] 약 26~33cm",
             ""
     ),
-    GENIETV("지니TV석",
+    GENIETV("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/genietv.svg",
+            "지니TV석",
             "테이블석이라 음식 취식이 편리한 구역이에요!",
             List.of("테이블석이라 음식 취식이 편리한 구역이에요!"),
             "해당 구역은 3루 테이블석이라 편하게 관람을 할 수 있어요.",
@@ -72,7 +74,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
             ""
     ),
     //특징 확인 필요
-    CENTER("중앙지정석",
+    CENTER("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/center.svg",
+            "중앙지정석",
             "특정 팀에 구애받지 않고 응원하는 구역!",
             List.of(
                     "특정 팀에 구애받지 않고 응원하는 분위기의 구역이에요!",
@@ -105,7 +108,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
                     [3루쪽] 약 25~30cm""",
             ""
     ),
-    YBOX("Y박스석",
+    YBOX("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/ybox.svg",
+            "Y박스석",
             "선수들을 가까이서 볼 수 있는 구역이에요!",
             List.of("선수들을 가까이서 볼 수 있는 구역이에요!"),
             "해당 구역은 1루 테이블석이라 편리하게 음식을 먹을 수 있어요.",
@@ -135,7 +139,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
             "약 32cm(11n열)~약 41cm(21n, 31n열)",
             ""
     ),
-    SKYBOX("스카이박스(4층)",
+    SKYBOX("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/skybox.svg",
+            "스카이박스(4층)",
             "회의실같은 내부에서 쾌적하게 야구를 볼 수 있는 구역!",
             List.of(
                     "회의실처럼 생긴 내부에서 쾌적하게 야구를 볼 수 있는 구역이에요!",
@@ -174,7 +179,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
                     1루와 가까운 스카이박스와 3루와 가까운 스카이박스가 있어요!
                     미리 위치를 확인해보시고 참고하시는 걸 추천드려요."""
     ),
-    SKYZONE("스카이존(5층)",
+    SKYZONE("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/skyzone.svg",
+            "스카이존(5층)",
             "높은 곳에서 경기를 한 눈에 볼 수 있는 구역!",
             List.of("높은 곳에서 경기를 한 눈에 볼 수 있는 구역이에요!"),
             "해당 구역은 높은 곳에 위치해있어요!",
@@ -210,7 +216,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
             "약 28cm(2열), 약 26cm(이외 열)",
             ""
     ),
-    EXITING("하이파이브존/익사이팅석",
+    EXCITING("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/exciting.svg",
+            "하이파이브존/익사이팅석",
             "경기 승리 시, 선수들과 하이파이브 할 수 있는 구역!",
             List.of(
                     "(1루 하이파이브존) KT가 경기 승리 시, 선수들과 하이파이브 할 수 있는 구역이에요! 전반적으로 앉아서 응원하는 분위기며, 선수들을 굉장히 가까이에서 볼 수 있는 구역이에요.",
@@ -270,7 +277,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
                     [익사이팅석] 약 37cm(1열), 39cm(2~6열)""",
             ""
     ),
-    SHOPPING("KT알파쇼핑석",
+    SHOPPING("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/shopping.svg",
+            "KT알파쇼핑석",
             "중앙테이블석이라, 음식 섭취하기 편한 구역이에요!",
             List.of("중앙테이블석이라, 음식 섭취하기 편한 구역이에요!"),
             "해당 구역은 중앙 테이블석이고, 빨리 예매하는 것이 좋아요.",
@@ -307,7 +315,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
             "약 44cm",
             ""
     ),
-    GENIE("지니존",
+    GENIE("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/genie.svg",
+            "지니존",
             "포수 바로 뒤에서 관람할 수 있는 구역이에요!",
             List.of("포수 바로 뒤에서 관람할 수 있는 구역이에요!"),
             "해당 구역은 경기를 생동감있게 볼 수 있어요.",
@@ -336,7 +345,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
             "약 30~34cm",
             ""
     ),
-    TVING("티빙 테이블석",
+    TVING("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/tving.svg",
+            "티빙 테이블석",
             "외야 테이블석이며, 2인 테이블 3개로 구성되어있는 구역이에요!",
             List.of("외야 테이블석이며, 2인 테이블 3개로 구성되어있는 구역이에요!"),
             "해당 구역은 외야 테이블석이에요.",
@@ -362,7 +372,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
             "약 49cm",
             ""
     ),
-    GRASS("외야 잔디 자유석",
+    GRASS("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/grass.svg",
+            "외야 잔디 자유석",
             "넓은 외야에 잔디가 깔려 있어 앉아서 관람할 수 있는 구역이에요! 계단처럼 층이 나뉘어져 있어요.",
             List.of(
                     "넓은 외야에 잔디가 깔려 있어 앉아서 관람할 수 있는 구역이에요!",
@@ -401,7 +412,8 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
                     외야잔디자유석의 경우, ‘바퀴’가 달린 것은 반입을 제한하고 있어요!
                     접이식 카트 등도 반입이 어려우니 참고하세요!"""
     ),
-    CAMPING("키즈랜드 캠핑존",
+    CAMPING("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/camping.svg",
+            "키즈랜드 캠핑존",
             """
                     텐트에서 야구를 볼 수 있는 구역이에요!
                     고기를 구워 먹는 것이 가능해요.""",
@@ -444,6 +456,7 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
     );
 
     private static final String DEFAULT_TITLE = "참고하세요";
+    private final String imgUrl;
     private final String zoneName;
     private final String oneLineDescription;
     private final List<String> explanations;

--- a/src/main/java/kusitms/backend/result/domain/enums/StadiumStatusType.java
+++ b/src/main/java/kusitms/backend/result/domain/enums/StadiumStatusType.java
@@ -5,6 +5,7 @@ import kusitms.backend.result.common.ReferencesGroup;
 import java.util.List;
 
 public interface StadiumStatusType {
+    String getImgUrl();
     String getZoneName();
     String getOneLineDescription();
     List<String> getExplanations();

--- a/src/main/java/kusitms/backend/stadium/dto/response/GetZoneGuideResponseDto.java
+++ b/src/main/java/kusitms/backend/stadium/dto/response/GetZoneGuideResponseDto.java
@@ -7,6 +7,7 @@ import kusitms.backend.result.domain.enums.StadiumStatusType;
 import java.util.List;
 
 public record GetZoneGuideResponseDto(
+        String imgUrl,
         String zoneName,
         String explanation,
         String entrance,
@@ -18,6 +19,7 @@ public record GetZoneGuideResponseDto(
 ) {
     public static GetZoneGuideResponseDto from(StadiumStatusType zone) {
         return new GetZoneGuideResponseDto(
+                zone.getImgUrl(),
                 zone.getZoneName(),
                 zone.getOneLineDescription(),
                 zone.getEntrance(),

--- a/src/test/java/kusitms/backend/stadium/StadiumControllerTest.java
+++ b/src/test/java/kusitms/backend/stadium/StadiumControllerTest.java
@@ -94,6 +94,7 @@ public class StadiumControllerTest extends ControllerTestConfig {
                 )
         );
         GetZoneGuideResponseDto getZoneGuideResponseDto = new GetZoneGuideResponseDto(
+                "https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/red.svg",
                 "레드석",
                 "해당 구역은 다양한 것들을 모두 적절히 즐길 수 있는 구역이에요.",
                 "[1루] 2-3 Gate [3루] 2-1 Gate",
@@ -120,6 +121,7 @@ public class StadiumControllerTest extends ControllerTestConfig {
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("해당 구역에 대한 가이드 정보가 조회되었습니다."))
+                .andExpect(jsonPath("$.payload.imgUrl").value("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/lg/red.svg"))
                 .andExpect(jsonPath("$.payload.zoneName").value("레드석"))
                 .andExpect(jsonPath("$.payload.explanation").value("해당 구역은 다양한 것들을 모두 적절히 즐길 수 있는 구역이에요."))
                 .andExpect(jsonPath("$.payload.entrance").value("[1루] 2-3 Gate [3루] 2-1 Gate"))
@@ -146,6 +148,7 @@ public class StadiumControllerTest extends ControllerTestConfig {
                                                 fieldWithPath("code").description("응답 코드"),
                                                 fieldWithPath("message").description("응답 메시지"),
                                                 fieldWithPath("payload").description("응답 데이터").optional(),
+                                                fieldWithPath("payload.imgUrl").description("이미지 URL"),
                                                 fieldWithPath("payload.zoneName").description("구역명"),
                                                 fieldWithPath("payload.explanation").description("구역 설명"),
                                                 fieldWithPath("payload.entrance").description("구역 입구"),


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 구역 가이드 정보 조회 시 이미지 URL을 함께 반환한다

<img width="1410" alt="스크린샷 2024-11-07 오후 6 04 13" src="https://github.com/user-attachments/assets/d9b84dee-24c7-446a-bd8e-10fdadf2834c">

<img width="623" alt="스크린샷 2024-11-07 오후 6 04 27" src="https://github.com/user-attachments/assets/916ebc61-a3b4-42b0-a4c4-80264251b58c">


---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #50 

---

## 🎸 기타 사항 or 추가 코멘트

아직 원본 svg 파일을 받지 못 해서 오늘 내로 Object Storage에 업로드 할 예정입니다!
링크 자체는 동일합니다.