### PR TITLE
[refactor] : global에서의 의존성을 제거하고, 닉네임 중복 확인 시 분산 락을 활용한다

### DIFF
--- a/src/main/java/kusitms/backend/auth/status/AuthErrorStatus.java
+++ b/src/main/java/kusitms/backend/auth/status/AuthErrorStatus.java
@@ -9,16 +9,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorStatus implements BaseErrorCode {
-    _MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-001", "쿠키에 토큰이 존재하지 않습니다."),
-    _EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-002", "쿠키의 토큰 값이 비어있습니다."),
-    _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-003", "유효하지 않은 토큰입니다."),
-    _NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "AUTH-004", "사용자 인증에 실패했습니다."),
-    _EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-005", "만료된 토큰입니다."),
-    _EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-006", "리프레쉬 토큰이 만료되었습니다. 재로그인을 시도해주세요."),
-    _EXPIRED_REGISTER_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-007", "추가정보 입력시간이 만료되었습니다. 재 회원가입을 시도해주세요."),
-    _NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "AUTH-008", "DB에 조건에 해당하는 토큰이 존재하지 않습니다."),
-    _TOKEN_USER_MISMATCH(HttpStatus.FORBIDDEN, "AUTH-009", "인증된 사용자 정보와 토큰이 일치하지 않습니다."),
-    _REDIS_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-010", "레디스에서 토큰을 찾을 수 없습니다."),
+    _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-001", "유효하지 않은 토큰입니다."),
+    _NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "AUTH-002", "사용자 인증에 실패했습니다."),
+    _EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-003", "만료된 토큰입니다."),
+    _EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-004", "리프레쉬 토큰이 만료되었습니다. 재로그인을 시도해주세요."),
+    _EXPIRED_REGISTER_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-005", "추가정보 입력시간이 만료되었습니다. 재 회원가입을 시도해주세요."),
+    _NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "AUTH-006", "DB에 조건에 해당하는 토큰이 존재하지 않습니다."),
+    _TOKEN_USER_MISMATCH(HttpStatus.FORBIDDEN, "AUTH-007", "인증된 사용자 정보와 토큰이 일치하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kusitms/backend/global/redis/DistributedLockManager.java
+++ b/src/main/java/kusitms/backend/global/redis/DistributedLockManager.java
@@ -1,0 +1,34 @@
+package kusitms.backend.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class DistributedLockManager {
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 분산락 획득 시도.
+     *
+     * @param lockKey   락 키
+     * @param timeoutMs 락 만료 시간 (밀리초)
+     * @return 락 획득 여부
+     */
+    public boolean acquireLock(String lockKey, long timeoutMs) {
+        Boolean isLocked = redisTemplate.opsForValue().setIfAbsent(lockKey, "LOCKED", timeoutMs, TimeUnit.MILLISECONDS);
+        return Boolean.TRUE.equals(isLocked);
+    }
+
+    /**
+     * 분산락 해제.
+     *
+     * @param lockKey 락 키
+     */
+    public void releaseLock(String lockKey) {
+        redisTemplate.delete(lockKey);
+    }
+}

--- a/src/main/java/kusitms/backend/global/redis/RedisManager.java
+++ b/src/main/java/kusitms/backend/global/redis/RedisManager.java
@@ -99,7 +99,7 @@ public class RedisManager {
         String token = redisTemplate.opsForValue().get(userId);
         if (token == null) {
             log.warn("Refresh token not found for userId: {}", userId);
-            throw new CustomException(AuthErrorStatus._REDIS_TOKEN_NOT_FOUND);
+            throw new CustomException(ErrorStatus._REDIS_TOKEN_NOT_FOUND);
         }
         return token;
     }

--- a/src/main/java/kusitms/backend/global/status/ErrorStatus.java
+++ b/src/main/java/kusitms/backend/global/status/ErrorStatus.java
@@ -32,7 +32,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // Common Errors
     _DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-001", "데이터를 찾을 수 없습니다."),
     _INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON-002", "잘못된 입력 값입니다."),
-    _RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-003", "요청한 리소스를 찾을 수 없습니다.");
+    _RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-003", "요청한 리소스를 찾을 수 없습니다."),
+
+    // Cookie Errors
+    _MISSING_TOKEN_IN_COOKIE(HttpStatus.UNAUTHORIZED, "COOKIE-001", "쿠키에 토큰이 존재하지 않습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kusitms/backend/global/util/CookieUtil.java
+++ b/src/main/java/kusitms/backend/global/util/CookieUtil.java
@@ -3,8 +3,8 @@ package kusitms.backend.global.util;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import kusitms.backend.auth.status.AuthErrorStatus;
 import kusitms.backend.global.exception.CustomException;
+import kusitms.backend.global.status.ErrorStatus;
 
 public class CookieUtil {
 
@@ -75,6 +75,6 @@ public class CookieUtil {
                 }
             }
         }
-        throw new CustomException(AuthErrorStatus._MISSING_TOKEN);
+        throw new CustomException(ErrorStatus._MISSING_TOKEN_IN_COOKIE);
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 아래의 코드 리뷰 코멘트를 해결하고자 하였습니다.

1. https://github.com/KUSITMS-30th-TEAM-A/backend/pull/44#discussion_r1827804028
```
의존성이 global <-> auth 처럼 되어있는것 같은데요.
global이라는 네이밍과 내부 클래스들을 봤을때, 모든 도메인에서 참조하는 공통 로직을 넣어주신거 global -> auth로 의존성이 생기면 어떤 단점이 있을까요?
```

`global` 패키지 하위에 있는 `RedisManager`와 `CookieUtil`이 `AuthErrorStatus`를 사용하면서 global -> auth로의 의존성이 발생했습니다. 이는 추후 순환 참조 문제 등이 발생할 수 있기에, `ErrorStatus`로 코드를 이동시키면서 해결하고자 하였습니다.

2. https://github.com/KUSITMS-30th-TEAM-A/backend/pull/44#discussion_r1827846713
```
2명의 유저가 동시에 A라는 이름으로 중복확인을 하고 한명이 먼저 가입해버린다면 어떻게 될까요?
두명의 유저 모두 사용가능한 닉네임 이라는 응답을 받겠지만 늦게 가입을 누른 한명은 가입 중간에 에러를 보게될겁니다.

그냥 에러를 보게 하고 재입력하게 해도 되지만, 닉네임 체크를 할때 정책에 따라 분산락을 획득한다든지 하는 재밌는 방식으로 풀어낼수도 있을거 같아요.
```

코드 리뷰에서 언급해 주신 문제 상황 (동시성 문제)를 처리하기 위해서, Redis를 활용한 분산 락을 구현했습니다.

> DistributedLockManager

```java
@Component
@RequiredArgsConstructor
public class DistributedLockManager {
    private final StringRedisTemplate redisTemplate;

    /**
     * 분산락 획득 시도.
     *
     * @param lockKey   락 키
     * @param timeoutMs 락 만료 시간 (밀리초)
     * @return 락 획득 여부
     */
    public boolean acquireLock(String lockKey, long timeoutMs) {
        Boolean isLocked = redisTemplate.opsForValue().setIfAbsent(lockKey, "LOCKED", timeoutMs, TimeUnit.MILLISECONDS);
        return Boolean.TRUE.equals(isLocked);
    }

    /**
     * 분산락 해제.
     *
     * @param lockKey 락 키
     */
    public void releaseLock(String lockKey) {
        redisTemplate.delete(lockKey);
    }
}
```

분산 락과 관련된 로직을 하는 클래스입니다. 
1) 락 키 (닉네임)를 가지고 Redis에 set을 시도하며, 이미 존재할 시 (누군가 5초 이내로 동일한 닉네임 중복 확인을 한 경우)에는 false를 반환합니다.
2) 분산락 해제 메서드의 경우에는 해당 닉네임이 최종적으로 허용된 경우에만 호출됩니다.

> UserService

```java
...

private static final long LOCK_TIMEOUT = 5000; // 5초

...

    /**
     * 닉네임 중복 확인.
     *
     * @param request 닉네임 중복 확인 요청 정보
     */
    @Transactional
    public void checkNickname(CheckNicknameRequestDto request) {
        String nickname = request.nickname();
        String lockKey = "lock:nickname:" + nickname;

        // 1. 락 획득 시도
        if (!distributedLockManager.acquireLock(lockKey, LOCK_TIMEOUT)) {
            throw new CustomException(UserErrorStatus._DUPLICATED_NICKNAME);
        }

        try {
            // 2. 닉네임 중복 확인
            User user = userRepository.findByNickname(nickname);
            if (user != null) {
                throw new CustomException(UserErrorStatus._DUPLICATED_NICKNAME);
            }

            log.info("닉네임 사용 가능: {}", nickname);
        } finally {
            // 3. 락 해제
            distributedLockManager.releaseLock(lockKey);
        }
    }
```

1) 락 획득 시도에서, `false`가 반환된 경우에는 중복된 닉네임이라는 에러를 반환합니다.
2) 해당 닉네임이 DB에 존재하는지 확인합니다.
3) 최종적으로 사용 가능한 닉네임이라면, 락을 해제하며 로직을 종료합니다.
4) 5초로 유효 기간을 지정했기에, 5초가 지나면 자동으로 Redis에서 제거됩니다

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

#78 

---

## 🎸 기타 사항 or 추가 코멘트

지금과 같은 분산락 방법에는 여러 허점들이 존재해서, Redis에서 제공하는 `Redlock` 이라는 알고리즘을 사용한다고 합니다.
이를 구현하고자 했지만 아직 이해도가 낮은 것 같아 추후 학습 후 도입해보려고 합니다!

[Redlock 참고 블로그1](https://medium.com/sjk5766/redis%EA%B0%80-%EC%A0%9C%EA%B3%B5%ED%95%98%EB%8A%94-redlock%EC%9D%84-%EC%95%8C%EC%95%84%EB%B3%B4%EC%9E%90-2feb7278411e)
[Redlock 참고 블로그2](https://velog.io/@youmakemesmile/Spring-DataJPA를-활용한-DataBase-Lock-Redis-Lock-적용)