### PR TITLE
[fix] : 스타디움 구역 정보 중복 & 구역 추천(KT) 문제를 해결한다

### DIFF
--- a/src/main/java/kusitms/backend/result/domain/enums/KtWizStadiumStatusType.java
+++ b/src/main/java/kusitms/backend/result/domain/enums/KtWizStadiumStatusType.java
@@ -11,7 +11,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public enum KtWizStadiumStatusType implements StadiumStatusType{
 
-    //특징 확인 필요
     CENTER("https://kr.object.ncloudstorage.com/hitzone-bucket/hitzone/guide/kt/center.svg",
             "중앙지정석",
             "#5E346E",

--- a/src/main/java/kusitms/backend/result/domain/enums/KtWizStadiumStatusType.java
+++ b/src/main/java/kusitms/backend/result/domain/enums/KtWizStadiumStatusType.java
@@ -125,10 +125,10 @@ public enum KtWizStadiumStatusType implements StadiumStatusType{
                             )
                     )
             ),
-            List.of("나 혼자", "같은 팀 팬과"),
-            List.of("열정적인 응원"),
             List.of(),
-            List.of("다른 팀 팬과", "큰 소리 싫어요", "음식 먹기 편한", "삼겹살 구워먹기 가능"),
+            List.of(),
+            List.of(),
+            List.of(),
             new String[]{"데이터 추가 입력 예정"},
             new String[]{"[1루] 약 27~32cm [3루] 약 27~32cm"},
             new String[]{"[1루] 약 28cm [3루] 약 26~33cm"},

--- a/src/main/java/kusitms/backend/stadium/application/StadiumService.java
+++ b/src/main/java/kusitms/backend/stadium/application/StadiumService.java
@@ -21,6 +21,13 @@ import static kusitms.backend.result.domain.enums.KtWizStadiumStatusType.CHEERIN
 @RequiredArgsConstructor
 public class StadiumService {
 
+    /**
+     * 주어진 경기장 이름에 대한 정보를 조회.
+     *
+     * @param stadiumName 경기장 이름
+     * @return 경기장 정보와 구역 정보 리스트를 포함하는 DTO
+     * @throws CustomException 유효하지 않은 경기장 이름이 주어진 경우
+     */
     @Transactional(readOnly = true)
     public GetStadiumInfosResponseDto getStadiumInfos(String stadiumName) {
         StadiumInfo stadiumInfo = getStadiumInfoByName(stadiumName);
@@ -29,22 +36,14 @@ public class StadiumService {
         return GetStadiumInfosResponseDto.of(stadiumInfo.getImgUrl(), stadiumInfo.getFirstBaseSide(), stadiumInfo.getThirdBaseSide(), zoneInfos);
     }
 
-    private StadiumInfo getStadiumInfoByName(String stadiumName) {
-        return switch (stadiumName) {
-            case "잠실종합운동장 (잠실)" -> StadiumInfo.LG_HOME;
-            case "수원KT위즈파크" -> StadiumInfo.KT_HOME;
-            default -> throw new CustomException(StadiumErrorStatus._NOT_FOUND_STADIUM);
-        };
-    }
-
-    private StadiumStatusType[] getStatusTypesByName(String stadiumName) {
-        return switch (stadiumName) {
-            case "잠실종합운동장 (잠실)" -> JamsilStadiumStatusType.values();
-            case "수원KT위즈파크" -> KtWizStadiumStatusType.values();
-            default -> throw new CustomException(StadiumErrorStatus._NOT_FOUND_STADIUM);
-        };
-    }
-
+    /**
+     * 주어진 경기장 이름에 해당하는 구역 정보를 조회.
+     *
+     * @param stadiumName 경기장 이름
+     * @param zoneName    구역 이름
+     * @return 구역 정보 DTO
+     * @throws CustomException 유효하지 않은 경기장 이름이나 구역 이름이 주어진 경우
+     */
     @Transactional(readOnly = true)
     public GetZoneGuideResponseDto getZoneGuide(String stadiumName, String zoneName) {
         StadiumStatusType zoneType = switch (stadiumName) {
@@ -55,6 +54,13 @@ public class StadiumService {
         return GetZoneGuideResponseDto.from(zoneType);
     }
 
+    /**
+     * 주어진 상태 타입 배열에서 특정 구역의 이름과 색상을 조회.
+     * CHEERING_DUMMY 구역은 제외됩니다.
+     *
+     * @param statusTypes 상태 타입 배열
+     * @return 구역 이름과 색상 정보를 담은 리스트
+     */
     private List<GetStadiumInfosResponseDto.ZoneInfo> getZonesNameAndColorFromStadium(StadiumStatusType[] statusTypes) {
         return Arrays.stream(statusTypes)
                 .filter(status -> status != CHEERING_DUMMY)
@@ -62,10 +68,48 @@ public class StadiumService {
                 .toList();
     }
 
+    /**
+     * 주어진 상태 타입 배열에서 특정 구역 이름과 일치하는 구역 정보를 조회.
+     *
+     * @param statusTypes 상태 타입 배열
+     * @param zoneName    구역 이름
+     * @return 일치하는 구역 정보
+     * @throws CustomException 일치하는 구역을 찾을 수 없는 경우
+     */
     private StadiumStatusType findZoneInStadium(StadiumStatusType[] statusTypes, String zoneName) {
         return Arrays.stream(statusTypes)
                 .filter(status -> status.getZoneName().equals(zoneName))
                 .findFirst()
                 .orElseThrow(() -> new CustomException(StadiumErrorStatus._NOT_FOUND_ZONE));
+    }
+
+    /**
+     * 주어진 경기장 이름에 대한 기본 정보를 조회.
+     *
+     * @param stadiumName 경기장 이름
+     * @return 경기장 기본 정보
+     * @throws CustomException 유효하지 않은 경기장 이름이 주어진 경우
+     */
+    private StadiumInfo getStadiumInfoByName(String stadiumName) {
+        return switch (stadiumName) {
+            case "잠실종합운동장 (잠실)" -> StadiumInfo.LG_HOME;
+            case "수원KT위즈파크" -> StadiumInfo.KT_HOME;
+            default -> throw new CustomException(StadiumErrorStatus._NOT_FOUND_STADIUM);
+        };
+    }
+
+    /**
+     * 주어진 경기장 이름에 대한 상태 타입 배열을 조회.
+     *
+     * @param stadiumName 경기장 이름
+     * @return 경기장 상태 타입 배열
+     * @throws CustomException 유효하지 않은 경기장 이름이 주어진 경우
+     */
+    private StadiumStatusType[] getStatusTypesByName(String stadiumName) {
+        return switch (stadiumName) {
+            case "잠실종합운동장 (잠실)" -> JamsilStadiumStatusType.values();
+            case "수원KT위즈파크" -> KtWizStadiumStatusType.values();
+            default -> throw new CustomException(StadiumErrorStatus._NOT_FOUND_STADIUM);
+        };
     }
 }

--- a/src/main/java/kusitms/backend/stadium/application/StadiumService.java
+++ b/src/main/java/kusitms/backend/stadium/application/StadiumService.java
@@ -15,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Arrays;
 import java.util.List;
 
+import static kusitms.backend.result.domain.enums.KtWizStadiumStatusType.CHEERING_DUMMY;
+
 @Service
 @RequiredArgsConstructor
 public class StadiumService {
@@ -55,6 +57,7 @@ public class StadiumService {
 
     private List<GetStadiumInfosResponseDto.ZoneInfo> getZonesNameAndColorFromStadium(StadiumStatusType[] statusTypes) {
         return Arrays.stream(statusTypes)
+                .filter(status -> status != CHEERING_DUMMY)
                 .map(status -> GetStadiumInfosResponseDto.ZoneInfo.of(status.getZoneName(), status.getZoneColor()))
                 .toList();
     }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스타디움 구역 정보 중복 문제 해결

```java
    private List<GetStadiumInfosResponseDto.ZoneInfo> getZonesNameAndColorFromStadium(StadiumStatusType[] statusTypes) {
        return Arrays.stream(statusTypes)
                .filter(status -> status != CHEERING_DUMMY)
                .map(status -> GetStadiumInfosResponseDto.ZoneInfo.of(status.getZoneName(), status.getZoneColor()))
                .toList();
    }
```

- `CHEERING_DUMMY`는 filter로 제외

### 구역 추천(KT) 문제 해결
- 배포 DB에 중복 데이터 존재 -> 제거함으로써 해결

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #88 

---

## 🎸 기타 사항 or 추가 코멘트